### PR TITLE
Correção do link do call for papers

### DIFF
--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -56,7 +56,7 @@
     <div class="content" id="content">
         <div class="wrapper">
             <% for section in @document.sections : %>
-            <section class="<%= section %>" id="<%= @document.labels[section].toLowerCase() %>">
+            <section class="<%= section %>" id="<%= @document.labels[section].toLowerCase().replace(/\s/g, '_') %>">
                 <h1 class="title"><%= @document.labels[section] %></h1>
                 <%- @tryPartial("#{section}.html.eco", ['section', @document.path], @) %>
             </section>
@@ -67,7 +67,7 @@
     <div class="footer">
         <div class="wrapper">
             <% for section in @document.footer : %>
-            <section class="<%= section %>" id="<%= @document.labels[section].toLowerCase() %>">
+            <section class="<%= section %>" id="<%= @document.labels[section].toLowerCase().replace(/\s/g, '_') %>">
                 <h1 class="title"><%= @document.labels[section] %></h1>
                 <%- @partial("section/#{section}.html.eco", @) %>
             </section>

--- a/src/partials/nav.html.eco
+++ b/src/partials/nav.html.eco
@@ -2,7 +2,7 @@
     <ul>
         <% for section in @document.sections : %>
         <li class="nav-item nav-item-<%= section %>">
-            <a href="#<%= @document.labels[section].toLowerCase() %>" title="<%= @document.labels[section] %>"><%= @document.labels[section] %></a>
+            <a href="#<%= @document.labels[section].toLowerCase().replace(/\s/g, '_') %>" title="<%= @document.labels[section] %>"><%= @document.labels[section] %></a>
         </li>
         <% end %>
     </ul>


### PR DESCRIPTION
The menu links and the section ids are generated automatically, with just a toLowerCase treatment, this way it keeps the spaces and makes the links break in some browsers.

With these changes, the spaces will be replaced by an underscore.

Another doubt: at README.md, the command to install should be `npm install -g docpad` instead of just `npm install docpad` isn't ?